### PR TITLE
Bugfix to gl.clearDepth(). Was calling undefined function glClearDepthf(...

### DIFF
--- a/src/webgl.cc
+++ b/src/webgl.cc
@@ -589,7 +589,7 @@ JS_METHOD(ClearDepth) {
 
   float depth = (float) args[0]->NumberValue();
 
-  glClearDepthf(depth);
+  glClearDepth(depth);
 
   return scope.Close(Undefined());
 }


### PR DESCRIPTION
...), causing a segmentation fault.
