### PR TITLE
fix issues with loading bindings with debug node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .idea
 Debug
 *.log
+node_modules

--- a/lib/image.js
+++ b/lib/image.js
@@ -1,5 +1,5 @@
 // javascript shim that lets our object inherit from EventEmitter
-var Image = module.exports = require('../build/Release/webgl.node').Image;
+var Image = module.exports = require('bindings')('webgl').Image;
 var events = require('events');
 
 

--- a/lib/webgl.js
+++ b/lib/webgl.js
@@ -1,4 +1,4 @@
-var gl = module.exports = require('../build/Release/webgl.node');
+var gl = module.exports = require('bindings')('webgl');
 var Image = require('./image');
 
 gl.WebGLProgram=function (_) { this._ = _; }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     }
   ],
   "dependencies": {
-    "node-glfw": ">=0.3.0",
-    "nan": "^0.8.0"
+    "bindings": "^1.2.1",
+    "nan": "^0.8.0",
+    "node-glfw": ">=0.3.0"
   }
 }


### PR DESCRIPTION
For various reasons I've installed this with node compiled with `--debug` which places the binaries in a debug dir instead of the hardcoded `build/Release` dir.  This patch uses the `bindings` module to fix this issue.
