### PR TITLE
Remove invalid window argument to SwapInterval

### DIFF
--- a/lib/platform_glfw.js
+++ b/lib/platform_glfw.js
@@ -107,7 +107,7 @@ module.exports = function () {
             WebGL.Init();
 
             GLFW.SwapBuffers(window);
-            GLFW.SwapInterval(window,0); // Disable VSync (we want to get as high FPS as possible!)
+            GLFW.SwapInterval(0); // Disable VSync (we want to get as high FPS as possible!)
 
             for (var l = 0, ln = resizeListeners.length; l < ln; ++l)
                 GLFW.events.addListener('resize', resizeListeners[l]);


### PR DESCRIPTION
GLFW.SwapInterval expects only one numeric argument:
https://github.com/mikeseven/node-glfw/blob/master/src/glfw.cc#L915
