### PR TITLE
Add HomeBrew include and library directories on Mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,8 +26,13 @@
         '<(module_root_dir)/deps/<(platform)',
       ],
       'conditions': [
-        ['OS=="mac"', {
-          'libraries': ['-lGLEW','-lfreeimage','-framework OpenGL']}],
+        ['OS=="mac"',
+          {
+            'libraries': ['-lGLEW','-lfreeimage','-framework OpenGL'],
+            'include_dirs': ['/usr/local/include'],
+            'library_dirs': ['/usr/local/lib'],
+          }
+        ],
         ['OS=="linux"', {'libraries': ['-lfreeimage','-lGLEW','-lGL']}],
         ['OS=="win"',
           {


### PR DESCRIPTION
The recent `clang` from `XCode` distribution does not look into `/usr/local/include`/`/usr/local/lib` directories. This patch adds them explicitly.
